### PR TITLE
Fix admin translations not being loaded in Safari

### DIFF
--- a/pimcore/static6/js/pimcore/overrides.js
+++ b/pimcore/static6/js/pimcore/overrides.js
@@ -13,7 +13,7 @@
 
 if(typeof window['t'] !== 'function') {
     // for compatibility reasons
-    function t(v) {return v;};
+    window.t = function(v) { return v; };
 }
 
 Ext.override(Ext.dd.DragDropMgr, {


### PR DESCRIPTION
In Pimcore 4 are the translations not loaded anymore, this is fixed in pimcore5. See related issue: #1997

## Fixes Issue #
#1997


